### PR TITLE
Add .gitignore, fix README and add command overview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.history

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# bash-shortcuts-flutter
+# flu.sh
 
-Just a helper bash repo for myself to not have to search and type all of these long flutter commands. 
+Just a helper bash repo for myself to not have to search and type all of these long flutter commands.
 This is just meant as inspiration and should not be copied 1:1, because there might be changes.
 
 Everything should work fine on Unix and OSX. Maybe it works in Windows as well, but not sure about it.
@@ -15,11 +15,18 @@ wget https://github.com/SimonErich/bash-shortcuts-flutter/blob/main/flu.sh ~/flu
 chmod +x ~/flu.sh
 ```
 
+or using cURL:
+
+```bash
+curl -L https://raw.githubusercontent.com/SimonErich/bash-shortcuts-flutter/main/flu.sh -o ~/flu.sh
+chmod +x ~/flu.sh
+```
+
 ## Linux & OSX
 
 Add it to your profile file. (`~/.zshrc` or `~/.bashrc` - depending on your shell):
 
-```
+```bash
 source ~/flu.sh
 ```
 
@@ -56,13 +63,12 @@ Shortcut for the command `flutter pub run build_runner --delete-conflicting-outp
 
 Shortcut for the command `flutter pub run build_runner watch --delete-conflicting-outputs`
 
-
 ## Further reading
 
 The script was created based on the following article: (with more explanation on syntax and workings)
-https://dev.to/eddeee888/how-to-write-a-bash-shortcut-script-to-enhance-your-terminal-experience-5898
+[https://dev.to/eddeee888/how-to-write-a-bash-shortcut-script-to-enhance-your-terminal-experience-5898](https://dev.to/eddeee888/how-to-write-a-bash-shortcut-script-to-enhance-your-terminal-experience-5898)
 
-<hr />
+---
 
 ### Specific commands to our environment
 
@@ -71,4 +77,3 @@ May not apply to your setup.
 #### flu widgetbook-build
 
 Shortcut for the command `flutter run  -t lib/widgetbook.widgetbook.dart -d chrome --web-renderer html --`
-

--- a/flu.sh
+++ b/flu.sh
@@ -81,6 +81,26 @@ function flu() {
     ;;
   esac
 
-  echo "\nERROR - Invalid command\n"
+  GREEN_FG='\033[32m'
+  BOLD='\033[1;97m'
+  TITLE='\033[1;42;97m'
+  NC='\033[0m' # No Color
+
+  usage="
+  ${TITLE} $(basename "$0") [command] -- small bash helper to abbreviate verbose flutter commands. ${NC}
+
+  ${BOLD}[command]:${NC}
+    ${GREEN_FG}get                  ${NC}flutter pub get
+    ${GREEN_FG}analyze              ${NC}flutter analyze
+    ${GREEN_FG}test                 ${NC}flutter test
+    ${GREEN_FG}format               ${NC}flutter format . (just analyzes, but does not fix)
+    ${GREEN_FG}format fix           ${NC}flutter format --fix . (analyzes and fixes problems)
+    ${GREEN_FG}runner               ${NC}flutter pub run build_runner --delete-conflicting-outputs
+    ${GREEN_FG}runner watch         ${NC}flutter pub run build_runner watch --delete-conflicting-outputs
+
+  ${BOLD}specific to our environment:
+    ${GREEN_FG}build-widgetbook     ${NC}flutter run -t lib/widgetbook.widgetbook.dart -d chrome --web-renderer html --\n"
+
+  echo "$usage"
   return 1
 }

--- a/flu.sh
+++ b/flu.sh
@@ -61,7 +61,7 @@ function flu() {
     case $2 in
     "")
       echo "Running flutter build runner once"
-      flutter pub run build_runner --delete-conflicting-outputs
+      flutter pub run build_runner build --delete-conflicting-outputs
       return 0
       ;;
     "watch")


### PR DESCRIPTION
This mainly fixes some formatting issues in the `README.md` as well as displays an overview of all available commands when either no command was specified or an unrecognized command was entered.

Also fixes issue #1.

Screenshot: 
<img width="731" alt="grafik" src="https://user-images.githubusercontent.com/35543080/176528914-2fe0ae3c-c468-414a-999d-4a8da6a8eeee.png">
